### PR TITLE
fix: correct the decryption algorithm to rs256

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,22 @@ Initialization requires 5 parameters, which are all str type:
 | endpoint         | Yes  | Casdoor Server Url, such as `http://localhost:8000` |
 | client_id         | Yes  | Application.client_id                               |
 | client_secret     | Yes  | Application.client_secret                           |
-| jwt_secret        | Yes  | Same as Casdoor JWT secret                         |
+| certificate       | Yes  | Same as Casdoor   certificate                     |
 | org_name | Yes  |Organization name
 
 ```python
 from casdoor import CasdoorSDK
 
+certificate = b'''-----BEGIN CERTIFICATE-----
+MIIE+TCCAuGgAwIBAgIDAeJAMA0GCSqGSIb3DQEBCwUAMDYxHTAbBgNVBAoTFENh
+...
+-----END CERTIFICATE-----'''
+
 sdk = CasdoorSDK(
     endpoint,
     client_id,
     client_secret,
-    jwt_secret,
+    certificate,
     org_name,
 )
 ```

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ setup_requires =
 install_requires = 
 	requests
 	pyjwt
+	cryptography
 python_requires = >=3.6
 test_suite = tests
 

--- a/src/tests/test_oauth.py
+++ b/src/tests/test_oauth.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from src.oauth.main import CasdoorSDK, User
+from src.casdoor.main import CasdoorSDK, User
 from unittest import TestCase
 
 


### PR DESCRIPTION
```python
cert = b'''-----BEGIN CERTIFICATE-----
MIIE+TCCAuGgAwIBAgIDAeJAMA0GCSqGSIb3DQEBCwUAMDYxHTAbBgNVBAoTFENh
...
-----END CERTIFICATE-----'''

sdk = CasdoorSDK(host,client_id,client_secret,cert,org,)
encoded = "eyJhb...."
print(sdk.parse_jwt_token(encoded))
```
```bash
{'owner': 'built-in', 'name': 'admin', 'scope': 'read', 'iss': 'http://localhost:8000', 'sub': '7a6b4a...', 'aud': ['c58c5...'], 'exp': 1648182846, 'nbf': 1647578046, 'iat': 1647578046}
```
Signed-off-by: Steve0x2a <stevesough@gmail.com>