### PR TITLE
certificate convert to bytes to meet cryptography needs.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = casdoor
-version = 1.1.3
+version = 1.1.4
 author = ffyuanda
 author_email = shaoxuan.yuan02@gmail.com
 url = https://github.com/casdoor/casdoor-python-sdk


### PR DESCRIPTION
# changes
In this pull request, I've made two change:

* optimize the import order, and add a new import of "cached_property"
* use a new function property to convert `str` type certificate to `bytes` type certification, this change is the main fix for this pull request