### PR TITLE
feat: Added ability to use Resource Owner Password Credentials Grant

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,12 +94,12 @@ listen to the response from `Casdoor`. For example, if your `redirect_uri` is `h
 
 After Casdoor verification passed, it will be redirected to your application with code and state as said in Step2, like `https://forum.casbin.com/callback?code=xxx&state=yyyy`.
 
-Your web application can get the `code` and call `get_oauth_token(code)`, then parse out jwt token.
+Your web application can get the `code` and call `get_oauth_token(code=code)`, then parse out jwt token.
 
 The general process is as follows:
 
 ```python
-access_token = sdk.get_oauth_token(code)
+access_token = sdk.get_oauth_token(code=code)
 decoded_msg = sdk.parse_jwt_token(access_token)
 ```
 
@@ -114,3 +114,15 @@ casdoor-python-sdk support basic user operations, like:
 - `modify_user(method: str, user: User)/add_user(user: User)/update_user(user: User)/delete_user(user: User)`, write user to database.
 - `refresh_token_request(refresh_token: str, scope: str)`, refresh access token
 - `enforce(self, permission_model_name: str, sub: str, obj: str, act: str)`, check permission from model
+
+
+## Also. Resource Owner Password Credentials Grant
+
+If your application doesn't have a frontend that redirects users to Casdoor and you have Password Credentials Grant enabled, then you may get access token like this:
+
+```python
+access_token = sdk.get_oauth_token(username=username, password=password)
+decoded_msg = sdk.parse_jwt_token(access_token)
+```
+
+`decoded_msg` is the JSON data decoded from the `access_token`, which contains user info and other useful stuff.

--- a/src/casdoor/async_main.py
+++ b/src/casdoor/async_main.py
@@ -120,7 +120,7 @@ class AsyncCasdoorSDK:
         """
         url = self.endpoint + "/api/login/oauth/refresh_token"
         params = {
-            "grant_type": self.grant_type,
+            "grant_type": "refresh_token",
             "client_id": self.client_id,
             "client_secret": self.client_secret,
             "scope": scope,

--- a/src/casdoor/main.py
+++ b/src/casdoor/main.py
@@ -114,7 +114,7 @@ class CasdoorSDK:
         """
         url = self.endpoint + "/api/login/oauth/refresh_token"
         params = {
-            "grant_type": self.grant_type,
+            "grant_type": "refresh_token",
             "client_id": self.client_id,
             "client_secret": self.client_secret,
             "scope": scope,


### PR DESCRIPTION
## Changes

- Fixed grant_type for refresh_token_request(). You don't need to manually change grant_type before starting the func and change it back after. 
- Added the ability to expand the code base for obtaining an access token with different grant types (Authorization Code Grant, Resource Owner Password Credentials Grant, Implicit Grant, etc.)
- Implemented getting access token using Resource Owner Password Credentials Grant.
- Added tests
- Updated README
- Added blank lines to function descriptions (Popular IDE PyCharm can't separate description from params without it when describing function).
Before:![Before](https://user-images.githubusercontent.com/37060845/217771220-66304a4a-b2ad-4ace-94bc-0ad7942a3205.png)
After:![After](https://user-images.githubusercontent.com/37060845/217771425-a44c84d5-98a4-489d-9ff8-29a394e57b9a.png)

## Notes

This PR does not break backward compatibility.