### PR TITLE
feat: add v3-v5 field into enforce function's arg.

### DIFF
--- a/src/casdoor/async_main.py
+++ b/src/casdoor/async_main.py
@@ -260,7 +260,10 @@ class AsyncCasdoorSDK:
             permission_model_name: str,
             sub: str,
             obj: str,
-            act: str
+            act: str,
+            v3: Optional[str] = None,
+            v4: Optional[str] = None,
+            v5: Optional[str] = None,
     ) -> bool:
         """
         Send data to Casdoor enforce API
@@ -269,6 +272,9 @@ class AsyncCasdoorSDK:
         :param sub: sub from Casbin
         :param obj: obj from Casbin
         :param act: act from Casbin
+        :param v3: v3 from Casbin
+        :param v4: v4 from Casbin
+        :param v5: v5 from Casbin
         """
         url = self.endpoint + "/api/enforce"
         query_params = {
@@ -280,6 +286,9 @@ class AsyncCasdoorSDK:
             "v0": sub,
             "v1": obj,
             "v2": act,
+            "v3": v3,
+            "v4": v4,
+            "v5": v5,
         }
         async with self._session.post(
                 url, params=query_params, json=params

--- a/src/casdoor/main.py
+++ b/src/casdoor/main.py
@@ -249,7 +249,10 @@ class CasdoorSDK:
             permission_model_name: str,
             sub: str,
             obj: str,
-            act: str
+            act: str,
+            v3: Optional[str] = None,
+            v4: Optional[str] = None,
+            v5: Optional[str] = None,
     ) -> bool:
         """
         Send data to Casdoor enforce API
@@ -258,6 +261,9 @@ class CasdoorSDK:
         :param sub: sub from Casbin
         :param obj: obj from Casbin
         :param act: act from Casbin
+        :param v3: v3 from Casbin
+        :param v4: v4 from Casbin
+        :param v5: v5 from Casbin
         """
         url = self.endpoint + "/api/enforce"
         query_params = {
@@ -269,6 +275,9 @@ class CasdoorSDK:
             "v0": sub,
             "v1": obj,
             "v2": act,
+            "v3": v3,
+            "v4": v4,
+            "v5": v5,
         }
         r = requests.post(url, json=params, params=query_params)
         if r.status_code != 200 or "json" not in r.headers["content-type"]:

--- a/src/tests/test_async_oauth.py
+++ b/src/tests/test_async_oauth.py
@@ -148,7 +148,10 @@ class TestOAuth(IsolatedAsyncioTestCase):
 
     def mocked_enforce_requests_post(*args, **kwargs):
         class MockResponse:
-            def __init__(self, json_data, status_code=200, headers={'content-type': 'json'}):
+            def __init__(self, 
+                         json_data, 
+                         status_code=200, 
+                         headers={'content-type': 'json'}):
                 self.json_data = json_data
                 self.status_code = status_code
                 self.headers = headers
@@ -162,11 +165,18 @@ class TestOAuth(IsolatedAsyncioTestCase):
 
         return MockResponse(result)
 
-    @mock.patch("aiohttp.ClientSession.post", side_effect=mocked_enforce_requests_post)
+    @mock.patch("aiohttp.ClientSession.post",
+                side_effect=mocked_enforce_requests_post)
     async def test_enforce_parmas(self, mock_post):
         sdk = self.get_sdk()
         status = await sdk.enforce(
-            "built-in/permission-built-in", "v0", "v1", "v2", v3='v3', v4='v4', v5='v5'
+            "built-in/permission-built-in",
+            "v0",
+            "v1",
+            "v2",
+            v3='v3',
+            v4='v4',
+            v5='v5'
         )
         self.assertEqual(status, True)
 
@@ -214,4 +224,3 @@ class TestOAuth(IsolatedAsyncioTestCase):
 
     def check_enforce_request(*args, **kwargs):
         return True
-    

--- a/src/tests/test_async_oauth.py
+++ b/src/tests/test_async_oauth.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest import IsolatedAsyncioTestCase
+from unittest import IsolatedAsyncioTestCase, mock
 
 from src.casdoor.async_main import AsyncCasdoorSDK, User
 
@@ -146,6 +146,30 @@ class TestOAuth(IsolatedAsyncioTestCase):
         )
         self.assertIsInstance(status, bool)
 
+    def mocked_enforce_requests_post(*args, **kwargs):
+        class MockResponse:
+            def __init__(self, json_data, status_code=200, headers={'content-type': 'json'}):
+                self.json_data = json_data
+                self.status_code = status_code
+                self.headers = headers
+
+            def json(self):
+                return self.json_data
+        result = True
+        for i in range(0, 5):
+            if kwargs.get('json').get(f"v{i}") != f"v{i}":
+                result = False
+
+        return MockResponse(result)
+
+    @mock.patch("aiohttp.ClientSession.post", side_effect=mocked_enforce_requests_post)
+    async def test_enforce_parmas(self, mock_post):
+        sdk = self.get_sdk()
+        status = await sdk.enforce(
+            "built-in/permission-built-in", "v0", "v1", "v2", v3='v3', v4='v4', v5='v5'
+        )
+        self.assertEqual(status, True)
+
     async def test_get_users(self):
         sdk = self.get_sdk()
         users = await sdk.get_users()
@@ -187,3 +211,7 @@ class TestOAuth(IsolatedAsyncioTestCase):
 
         self.assertIn("status", response)
         self.assertIsInstance(response, dict)
+
+    def check_enforce_request(*args, **kwargs):
+        return True
+    

--- a/src/tests/test_async_oauth.py
+++ b/src/tests/test_async_oauth.py
@@ -148,9 +148,9 @@ class TestOAuth(IsolatedAsyncioTestCase):
 
     def mocked_enforce_requests_post(*args, **kwargs):
         class MockResponse:
-            def __init__(self, 
-                         json_data, 
-                         status_code=200, 
+            def __init__(self,
+                         json_data,
+                         status_code=200,
                          headers={'content-type': 'json'}):
                 self.json_data = json_data
                 self.status_code = status_code

--- a/src/tests/test_oauth.py
+++ b/src/tests/test_oauth.py
@@ -150,7 +150,10 @@ class TestOAuth(TestCase):
 
     def mocked_enforce_requests_post(*args, **kwargs):
         class MockResponse:
-            def __init__(self, json_data, status_code=200, headers={'content-type': 'json'}):
+            def __init__(self, 
+                         json_data, 
+                         status_code=200, 
+                         headers={'content-type': 'json'}):
                 self.json_data = json_data
                 self.status_code = status_code
                 self.headers = headers
@@ -168,7 +171,13 @@ class TestOAuth(TestCase):
     def test_enforce_parmas(self, mock_post):
         sdk = self.get_sdk()
         status = sdk.enforce(
-            "built-in/permission-built-in", "v0", "v1", "v2", v3='v3', v4='v4', v5='v5'
+            "built-in/permission-built-in",
+            "v0",
+            "v1",
+            "v2",
+            v3='v3',
+            v4='v4',
+            v5='v5'
         )
         self.assertEqual(status, True)
 

--- a/src/tests/test_oauth.py
+++ b/src/tests/test_oauth.py
@@ -167,7 +167,8 @@ class TestOAuth(TestCase):
 
         return MockResponse(result)
 
-    @mock.patch("requests.post", side_effect=mocked_enforce_requests_post)
+    @mock.patch("requests.post",
+                side_effect=mocked_enforce_requests_post)
     def test_enforce_parmas(self, mock_post):
         sdk = self.get_sdk()
         status = sdk.enforce(

--- a/src/tests/test_oauth.py
+++ b/src/tests/test_oauth.py
@@ -150,9 +150,9 @@ class TestOAuth(TestCase):
 
     def mocked_enforce_requests_post(*args, **kwargs):
         class MockResponse:
-            def __init__(self, 
-                         json_data, 
-                         status_code=200, 
+            def __init__(self,
+                         json_data,
+                         status_code=200,
                          headers={'content-type': 'json'}):
                 self.json_data = json_data
                 self.status_code = status_code

--- a/src/tests/test_oauth.py
+++ b/src/tests/test_oauth.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest import TestCase
+from unittest import TestCase, mock
 
 from requests import Response
 
@@ -147,6 +147,30 @@ class TestOAuth(TestCase):
             "built-in/permission-built-in", "admin", "a", "ac"
         )
         self.assertIsInstance(status, bool)
+
+    def mocked_enforce_requests_post(*args, **kwargs):
+        class MockResponse:
+            def __init__(self, json_data, status_code=200, headers={'content-type': 'json'}):
+                self.json_data = json_data
+                self.status_code = status_code
+                self.headers = headers
+
+            def json(self):
+                return self.json_data
+        result = True
+        for i in range(0, 5):
+            if kwargs.get('json').get(f"v{i}") != f"v{i}":
+                result = False
+
+        return MockResponse(result)
+
+    @mock.patch("requests.post", side_effect=mocked_enforce_requests_post)
+    def test_enforce_parmas(self, mock_post):
+        sdk = self.get_sdk()
+        status = sdk.enforce(
+            "built-in/permission-built-in", "v0", "v1", "v2", v3='v3', v4='v4', v5='v5'
+        )
+        self.assertEqual(status, True)
 
     def test_get_users(self):
         sdk = self.get_sdk()


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor-python-sdk/issues/43