### PR TITLE
feat: support kwargs in parse_jwt_token()

### DIFF
--- a/src/casdoor/main.py
+++ b/src/casdoor/main.py
@@ -223,7 +223,7 @@ class CasdoorSDK:
 
         return access_token
 
-    def parse_jwt_token(self, token: str) -> dict:
+    def parse_jwt_token(self, token: str, **kwargs) -> dict:
         """
         Converts the returned access_token to real data using
         jwt (JSON Web Token) algorithms.
@@ -241,6 +241,7 @@ class CasdoorSDK:
             certificate.public_key(),
             algorithms=self.algorithms,
             audience=self.client_id,
+            **kwargs
         )
         return return_json
 


### PR DESCRIPTION
translate: 
if the generated token is  parsed, an nbf error will be reported. Here you can allow to manually set the error through the parameter leeway to solve this problem.