### PR TITLE
feat: python 3.12 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11"
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12"
 ]
 requires-python = ">=3.6"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp~=3.8.6
+aiohttp~=3.8
 cryptography~=41.0.5
 PyJWT~=2.8.0
 requests~=2.31.0


### PR DESCRIPTION
The `aiohttp` package has started releasing wheels for Python 3.12 since version 3.9.*, necessitating a relaxation of the current restrictions.