### PR TITLE
feat: add refresh_oauth_tokens() API

### DIFF
--- a/src/casdoor/main.py
+++ b/src/casdoor/main.py
@@ -223,6 +223,7 @@ class CasdoorSDK(
     def refresh_oauth_token(self, refresh_token: str, scope: str = "") -> str:
         """
         Request the Casdoor server to get access_token.
+        
         :param refresh_token: refresh_token for send to Casdoor
         :param scope: OAuth scope
         :return: Response from Casdoor
@@ -235,6 +236,7 @@ class CasdoorSDK(
     def refresh_oauth_tokens(self, refresh_token: str, scope: str = "") -> Dict:
         """
         Request the Casdoor server to get a refreshed Token.
+        
         :param refresh_token: refresh_token for send to Casdoor
         :param scope: OAuth scope
         :return: Response from Casdoor

--- a/src/casdoor/main.py
+++ b/src/casdoor/main.py
@@ -220,7 +220,7 @@ class CasdoorSDK(
         }
         return requests.post(url, params)
 
-    def refresh_oauth_token(self, refresh_token: str, scope: str = "") -> str:
+    def refresh_oauth_token(self, refresh_token: str, scope: str = "") -> str, str:
         """
         Request the Casdoor server to get access_token.
 
@@ -230,8 +230,8 @@ class CasdoorSDK(
         """
         r = self.refresh_token_request(refresh_token, scope)
         access_token = r.json().get("access_token")
-
-        return access_token
+        new_refresh_token = r.json().get("refresh_token")
+        return access_token , new_refresh_token
 
     def parse_jwt_token(self, token: str, **kwargs) -> Dict:
         """

--- a/src/casdoor/main.py
+++ b/src/casdoor/main.py
@@ -220,7 +220,7 @@ class CasdoorSDK(
         }
         return requests.post(url, params)
 
-    def refresh_oauth_token(self, refresh_token: str, scope: str = "") -> str, str:
+    def refresh_oauth_token(self, refresh_token: str, scope: str = "") -> tuple[str, str]:
         """
         Request the Casdoor server to get access_token.
 

--- a/src/casdoor/main.py
+++ b/src/casdoor/main.py
@@ -223,7 +223,7 @@ class CasdoorSDK(
     def refresh_oauth_token(self, refresh_token: str, scope: str = "") -> str:
         """
         Request the Casdoor server to get access_token.
-        
+
         :param refresh_token: refresh_token for send to Casdoor
         :param scope: OAuth scope
         :return: Response from Casdoor
@@ -236,7 +236,7 @@ class CasdoorSDK(
     def refresh_oauth_tokens(self, refresh_token: str, scope: str = "") -> Dict:
         """
         Request the Casdoor server to get a refreshed Token.
-        
+
         :param refresh_token: refresh_token for send to Casdoor
         :param scope: OAuth scope
         :return: Response from Casdoor
@@ -245,7 +245,7 @@ class CasdoorSDK(
         refreshed_token = r.json()
 
         return refreshed_token
-        
+
     def parse_jwt_token(self, token: str, **kwargs) -> Dict:
         """
         Converts the returned access_token to real data using

--- a/src/casdoor/main.py
+++ b/src/casdoor/main.py
@@ -220,19 +220,30 @@ class CasdoorSDK(
         }
         return requests.post(url, params)
 
-    def refresh_oauth_token(self, refresh_token: str, scope: str = "") -> tuple[str, str]:
+    def refresh_oauth_token(self, refresh_token: str, scope: str = "") -> str:
         """
         Request the Casdoor server to get access_token.
-
         :param refresh_token: refresh_token for send to Casdoor
         :param scope: OAuth scope
         :return: Response from Casdoor
         """
         r = self.refresh_token_request(refresh_token, scope)
         access_token = r.json().get("access_token")
-        new_refresh_token = r.json().get("refresh_token")
-        return access_token , new_refresh_token
 
+        return access_token
+
+    def refresh_oauth_tokens(self, refresh_token: str, scope: str = "") -> Dict:
+        """
+        Request the Casdoor server to get a refreshed Token.
+        :param refresh_token: refresh_token for send to Casdoor
+        :param scope: OAuth scope
+        :return: Response from Casdoor
+        """
+        r = self.refresh_token_request(refresh_token, scope)
+        refreshed_token = r.json()
+
+        return refreshed_token
+        
     def parse_jwt_token(self, token: str, **kwargs) -> Dict:
         """
         Converts the returned access_token to real data using


### PR DESCRIPTION
The refresh_token can be used only once 
Users will need the new refresh_token, which is included in the API response, in order to call the refresh_oauth_token again if needed.