### PR TITLE
feat: fix JSON serialization error in get_groups() API

### DIFF
--- a/src/casdoor/group.py
+++ b/src/casdoor/group.py
@@ -32,10 +32,10 @@ class Group:
         self.type = ""
         self.parentId = ""
         self.isTopGroup = False
-        self.users = [User]
+        self.users: List[User] = []
         self.title = ""
         self.key = ""
-        self.children = [Group]
+        self.children: List[Group] = []
         self.isEnabled = False
 
     @classmethod


### PR DESCRIPTION
This PR fixes a JSON serialization bug in the Group class. Currently, the Group class initializes its users and children attributes with class objects ([User] and [Group]) instead of empty lists, causing JSON serialization errors when these objects are returned from API endpoints.
The issue occurs because Python cannot serialize class objects to JSON, resulting in the error: TypeError: 'builtin_function_or_method' object is not iterable.
This PR initializes these attributes with empty lists ([]) and adds proper type hints to maintain code clarity and type safety.