### PR TITLE
add invitation&invitationCode properties in User class.

### DIFF
--- a/src/casdoor/user.py
+++ b/src/casdoor/user.py
@@ -50,6 +50,8 @@ class User:
         self.updatedTime = ""
         self.wechat = ""
         self.weibo = ""
+        self.invitation = ""
+        self.invitationCode = ""
 
     @classmethod
     def new(cls, owner, name, created_time, display_name):


### PR DESCRIPTION
related to [issue 96](https://github.com/casdoor/casdoor-python-sdk/issues/96)

## Summary

This pull request adds two missing fields, `invitation` and `invitationCode`, to the `User` class in the Casdoor Python SDK.

These fields are present in the `/api/get-user` RESTful API response but were not previously defined in the SDK's `User` object, resulting in potential `AttributeError` when accessed in downstream applications.

## Changes

- Modified the `User` class to include:

```python
self.invitation = ""
self.invitationCode = ""
